### PR TITLE
feat: Upgrade Facebook to v18

### DIFF
--- a/src/testUsers.js
+++ b/src/testUsers.js
@@ -4,7 +4,7 @@ const get = require('lodash/get');
 const merge = require('lodash/merge');
 const zip = require('lodash/zip');
 
-const GRAPH_API_BASE = 'https://graph.facebook.com/v10.0';
+const GRAPH_API_BASE = 'https://graph.facebook.com/v18.0';
 
 class Application {
   static async getAccessToken ({ appId, appSecret }) {

--- a/test/helpers/facebook.js
+++ b/test/helpers/facebook.js
@@ -6,7 +6,7 @@ const uuid = require('uuid/v4');
 
 const { URLSearchParams } = require('url');
 
-const GRAPH_API_BASE = '/v10.0';
+const GRAPH_API_BASE = '/v18.0';
 const GRAPH_API_HOST = 'https://graph.facebook.com';
 
 const createContext = () => {


### PR DESCRIPTION
According to the [Facebook changelog](https://developers.facebook.com/docs/graph-api/changelog/versions), nothing interesting changed in the user endpoints. The `/accounts` endpoint changed to remove business pages in some situations, but that should not effect us. Support for v12 is dropping in Feb.